### PR TITLE
docs: update icon theming installation commands

### DIFF
--- a/docs/content/1.getting-started/3.theming.md
+++ b/docs/content/1.getting-started/3.theming.md
@@ -120,15 +120,15 @@ However, you will need to install the icon packages you want to use.
 ::code-group
 
 ```bash [yarn]
-yarn add -D @iconify/json-{collection_name}
+yarn add -D @iconify-json/{collection_name}
 ```
 
 ```bash [npm]
-npm install -D @iconify/json-{collection_name}
+npm install -D @iconify-json/{collection_name}
 ```
 
 ```sh [pnpm]
-pnpm i -D @iconify/json-{collection_name}
+pnpm i -D @iconify-json/{collection_name}
 ```
 
 ::


### PR DESCRIPTION
Update install commands in theming documentation for customizing iconify pack based on installation steps from https://github.com/egoist/tailwindcss-icons