### PR TITLE
fix(ButtonGroup/AvatarGroup): allow `v-for`

### DIFF
--- a/src/runtime/components/elements/AvatarGroup.ts
+++ b/src/runtime/components/elements/AvatarGroup.ts
@@ -36,10 +36,15 @@ export default defineComponent({
 
     const children = computed(() => {
       let children = slots.default?.()
-      // @ts-ignore-next
-      if (children.length && children[0].type.name === 'ContentSlot') {
+      if (children.length) {
+        if (typeof children[0].type === 'symbol') {
+          // @ts-ignore-next
+          children = children[0].children
         // @ts-ignore-next
-        children = children[0].ctx.slots.default?.()
+        } else if (children[0].type.name === 'ContentSlot') {
+          // @ts-ignore-next
+          children = children[0].ctx.slots.default?.()
+        }
       }
       return children
     })

--- a/src/runtime/components/elements/ButtonGroup.ts
+++ b/src/runtime/components/elements/ButtonGroup.ts
@@ -30,10 +30,15 @@ export default defineComponent({
 
     const children = computed(() => {
       let children = slots.default?.()
-      // @ts-ignore-next
-      if (children.length && children[0].type.name === 'ContentSlot') {
+      if (children.length) {
+        if (children[0].type === Symbol.for('v-fgt')) {
+          // @ts-ignore-next
+          children = children[0].children
         // @ts-ignore-next
-        children = children[0].ctx.slots.default?.()
+        } else if (children[0].type.name === 'ContentSlot') {
+          // @ts-ignore-next
+          children = children[0].ctx.slots.default?.()
+        }
       }
       return children
     })

--- a/src/runtime/components/elements/ButtonGroup.ts
+++ b/src/runtime/components/elements/ButtonGroup.ts
@@ -31,7 +31,7 @@ export default defineComponent({
     const children = computed(() => {
       let children = slots.default?.()
       if (children.length) {
-        if (children[0].type === Symbol.for('v-fgt')) {
+        if (typeof children[0].type === 'symbol') {
           // @ts-ignore-next
           children = children[0].children
         // @ts-ignore-next


### PR DESCRIPTION
```vue
<UButtonGroup size="md">
  <UButton
    v-for="type in ['One', 'Two', 'Three']"
    :key="type"
    :label="type"
    color="white"
  />
</UButtonGroup>
```

Currently this fails, since the first child of ButtonGroup will be a Fragment.