### PR TITLE
docs: fix copy button overlap code content

### DIFF
--- a/docs/components/content/prose/ProseCode.vue
+++ b/docs/components/content/prose/ProseCode.vue
@@ -50,7 +50,7 @@ export default defineComponent({
   <div class="group relative" :class="`language-${language}`">
     <UButton
       :icon="icon"
-      variant="link"
+      variant="solid"
       class="absolute right-3 top-3 opacity-0 group-hover:opacity-100 transition-opacity z-[1]"
       size="xs"
       tabindex="-1"


### PR DESCRIPTION
Resolve #193 

Before:
<img width="751" alt="image" src="https://github.com/nuxtlabs/ui/assets/32187085/cd61165d-6e8f-4456-b76d-38f12d735ca5">

After:
<img width="745" alt="image" src="https://github.com/nuxtlabs/ui/assets/32187085/31159019-fbf3-4b0b-8748-f4b630f262db">
