### PR TITLE
docs(github, button): support for various file extensions

### DIFF
--- a/docs/components/docs/DocsPageHeader.vue
+++ b/docs/components/docs/DocsPageHeader.vue
@@ -22,7 +22,7 @@
           label="GitHub"
           icon="i-simple-icons-github"
           color="white"
-          :to="`https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/${page._dir}/${page.title.replace(' ', '')}.vue`"
+          :to="`https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/${page._dir}/${page.title.replace(' ', '')}${page.github.suffix || '.vue'}`"
         />
       </div>
     </div>

--- a/docs/content/3.forms/8.form-group.md
+++ b/docs/content/3.forms/8.form-group.md
@@ -1,5 +1,6 @@
 ---
-github: true
+github: 
+  suffix: .ts
 description: Display a label and additional informations around a form element.
 ---
 


### PR DESCRIPTION
One of the recent new components has a `.ts` ending instead of `.vue`, which resulted in a 404 when clicking the button in the documentation.

This Pro adds support for setting a file ending other than `.vue` if needed.