### PR TITLE
feat(table): add loading state 🔃

### DIFF
--- a/docs/components/content/examples/TableExampleLoadingSlot.vue
+++ b/docs/components/content/examples/TableExampleLoadingSlot.vue
@@ -1,0 +1,31 @@
+<script setup>
+const columns = [{
+  key: 'name',
+  label: 'Name'
+}, {
+  key: 'title',
+  label: 'Title'
+}, {
+  key: 'email',
+  label: 'Email'
+}, {
+  key: 'role',
+  label: 'Role'
+}, {
+  key: 'actions'
+}]
+
+const people = []
+
+const isLoading = ref(true);
+</script>
+
+<template>
+  <UTable :rows="people" :columns="columns" :is-loading="isLoading">
+    <template #loading-state>
+      <div class="flex items-center justify-center">
+        <span class="py-10">Loading...</span>
+      </div>
+    </template>
+  </UTable>
+</template>

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -400,6 +400,59 @@ excludedProps:
 ---
 ::
 
+### Loading
+
+Use the `is-loading` prop to display a loading state. it's used for async data fetching.
+
+You can pass an `object` through the `loading-state` prop or globally through `ui.table.default.loadingState`.
+
+::component-card
+---
+padding: false
+overflowClass: 'overflow-x-auto'
+baseProps:
+  class: 'w-full'
+  columns:
+    - key: 'id'
+      label: 'ID'
+    - key: 'name'
+      label: 'Name'
+    - key: 'title'
+      label: 'Title'
+    - key: 'email'
+      label: 'Email'
+    - key: 'role'
+      label: 'Role'
+props:
+  isLoading: true
+  loadingState:
+    icon: 'i-heroicons-arrow-path animate-spin'
+    label: "Loading..."
+excludedProps:
+  - isLoading
+  - loadingState
+---
+::
+
+#### Example with async data
+
+```vue
+<script setup>
+const columns = [...]
+const people = ref([...])
+const isLoading = ref(true)
+
+const getPeople = async () => {
+  // await fetch data from API and set people ...
+
+  isLoading.value = false
+}
+</script>
+
+<template>
+  <UTable :rows="people" :columns="columns" :is-loading="isLoading" />
+</template>
+```
 ## Slots
 
 You can use slots to customize the header and data cells of the table.
@@ -476,6 +529,39 @@ const selected = ref([people[1]])
       <UDropdown :items="items(row)">
         <UButton color="gray" variant="ghost" icon="i-heroicons-ellipsis-horizontal-20-solid" />
       </UDropdown>
+    </template>
+  </UTable>
+</template>
+```
+::
+
+### `loading-state`
+
+Use the `#loading-state` slot to customize the loading state.
+
+::component-example{class="grid"}
+---
+padding: false
+overflowClass: 'overflow-x-auto'
+---
+
+#default
+:table-example-loading-slot{class="flex-1"}
+
+#code
+```vue
+<script setup>
+const columns = [...]
+
+const people = [...]
+</script>
+
+<template>
+  <UTable :rows="people" :columns="columns" :is-loading="isLoading">
+    <template #loading-state>
+      <div class="flex items-center justify-center">
+          <span class="py-10">Loading...</span>
+      </div>
     </template>
   </UTable>
 </template>

--- a/src/runtime/app.config.ts
+++ b/src/runtime/app.config.ts
@@ -29,6 +29,11 @@ const table = {
     label: 'text-sm text-center text-gray-900 dark:text-white',
     icon: 'w-6 h-6 mx-auto text-gray-400 dark:text-gray-500 mb-4'
   },
+  loadingState: {
+    wrapper: 'flex items-center justify-center px-6 py-10 sm:px-10',
+    label: 'text-sm text-center text-gray-900 dark:text-white ml-2',
+    icon: 'w-5 h-5 text-gray-400 dark:text-gray-500'
+  },
   default: {
     sortAscIcon: 'i-heroicons-bars-arrow-up-20-solid',
     sortDescIcon: 'i-heroicons-bars-arrow-down-20-solid',
@@ -43,6 +48,10 @@ const table = {
     emptyState: {
       icon: 'i-heroicons-circle-stack-20-solid',
       label: 'No items.'
+    },
+    loadingState: {
+      icon: 'i-heroicons-arrow-path animate-spin',
+      label: 'Loading...',
     }
   }
 }

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -34,7 +34,7 @@
           </td>
         </tr>
 
-        <tr v-if="emptyState && !rows.length">
+        <tr v-if="emptyState && !rows.length && !isLoading">
           <td :colspan="columns.length">
             <div :class="ui.emptyState.wrapper">
               <UIcon v-if="emptyState.icon" :name="emptyState.icon" :class="ui.emptyState.icon" aria-hidden="true" />
@@ -42,6 +42,17 @@
                 {{ emptyState.label }}
               </p>
             </div>
+
+        <tr v-if="isLoading">
+          <td :colspan="columns.length">
+            <slot name="loading-state">
+              <div :class="ui.loadingState.wrapper">
+                <UIcon v-if="loadingState.icon" :name="loadingState.icon" :class="ui.loadingState.icon" aria-hidden="true" />
+                <p :class="ui.loadingState.label">
+                  {{ loadingState.label }}
+                </p>
+              </div>
+            </slot>
           </td>
         </tr>
       </tbody>
@@ -111,6 +122,14 @@ export default defineComponent({
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.table>>,
       default: () => appConfig.ui.table
+    },
+    isLoading: {
+      type: Boolean,
+      default: false
+    },
+    loadingState: {
+      type: Object as PropType<{ icon: string, label: string }>,
+      default: () => appConfig.ui.table.default.loadingState
     }
   },
   emits: ['update:modelValue'],


### PR DESCRIPTION
## Loading State in Table

The loading state is used to display loading in a table, typically when fetching data asynchronously. It is commonly used in scenarios where data needs to be retrieved from an API or server before it can be displayed.