### PR TITLE
feat(table): add slot for empty state

### DIFF
--- a/docs/components/content/examples/TableExampleEmptySlot.vue
+++ b/docs/components/content/examples/TableExampleEmptySlot.vue
@@ -20,7 +20,7 @@ const people = []
 
 <template>
   <UTable :rows="people" :columns="columns">
-    <template #empty>
+    <template #empty-state>
       <div class="flex flex-col items-center justify-center py-5">
           <span>No people</span>
           <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>

--- a/docs/components/content/examples/TableExampleEmptySlot.vue
+++ b/docs/components/content/examples/TableExampleEmptySlot.vue
@@ -20,9 +20,10 @@ const people = []
 
 <template>
   <UTable :rows="people" :columns="columns">
-    <template #empty-state>
-      <div class="flex items-center justify-center">
-          <span class="py-10">No Data.</span>
+    <template #empty>
+      <div class="flex flex-col items-center justify-center py-5">
+          <span>No people</span>
+          <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>
       </div>
     </template>
   </UTable>

--- a/docs/components/content/examples/TableExampleEmptySlot.vue
+++ b/docs/components/content/examples/TableExampleEmptySlot.vue
@@ -21,9 +21,9 @@ const people = []
 <template>
   <UTable :rows="people" :columns="columns">
     <template #empty-state>
-      <div class="flex flex-col items-center justify-center py-5">
-          <span>No people</span>
-          <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>
+      <div class="flex flex-col items-center justify-center py-6 gap-3">
+        <span class="italic text-sm">No one here!</span>
+        <UButton label="Add people" />
       </div>
     </template>
   </UTable>

--- a/docs/components/content/examples/TableExampleEmptySlot.vue
+++ b/docs/components/content/examples/TableExampleEmptySlot.vue
@@ -1,0 +1,29 @@
+<script setup>
+const columns = [{
+  key: 'name',
+  label: 'Name'
+}, {
+  key: 'title',
+  label: 'Title'
+}, {
+  key: 'email',
+  label: 'Email'
+}, {
+  key: 'role',
+  label: 'Role'
+}, {
+  key: 'actions'
+}]
+
+const people = []
+</script>
+
+<template>
+  <UTable :rows="people" :columns="columns">
+    <template #empty-state>
+      <div class="flex items-center justify-center">
+          <span class="py-10">No Data.</span>
+      </div>
+    </template>
+  </UTable>
+</template>

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -482,9 +482,9 @@ const selected = ref([people[1]])
 ```
 ::
 
-### `empty`
+### `empty-state`
 
-Use the `#empty` slot to customize the empty state.
+Use the `#empty-state` slot to customize the empty state.
 
 ::component-example{class="grid"}
 ---
@@ -504,7 +504,7 @@ const people = [...]
 
 <template>
   <UTable :rows="people" :columns="columns">
-    <template #empty>
+    <template #empty-state>
       <div class="flex flex-col items-center justify-center py-5">
           <span>No people</span>
           <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -482,6 +482,37 @@ const selected = ref([people[1]])
 ```
 ::
 
+### `empty-state`
+
+Use the `#empty-state` slot to customize the empty state.
+
+::component-example{class="grid"}
+---
+padding: false
+overflowClass: 'overflow-x-auto'
+---
+
+#default
+:table-example-empty-slot{class="flex-1"}
+
+#code
+```vue
+<script setup>
+const columns = [...]
+const people = [...]
+</script>
+<template>
+  <UTable :rows="people" :columns="columns">
+    <template #empty-state>
+      <div class="flex items-center justify-center">
+        <span class="py-10">No Data.</span>
+      </div>
+    </template>
+  </UTable>
+</template>
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -505,12 +505,12 @@ const people = [...]
 <template>
   <UTable :rows="people" :columns="columns">
     <template #empty-state>
-      <div class="flex flex-col items-center justify-center py-5">
-          <span>No people</span>
-          <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>
+      <div class="flex flex-col items-center justify-center py-6 gap-3">
+        <span class="italic text-sm">No one here!</span>
+        <UButton label="Add people" />
       </div>
     </template>
-  </UTable> 
+  </UTable>
 </template>
 ```
 ::

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -482,9 +482,9 @@ const selected = ref([people[1]])
 ```
 ::
 
-### `empty-state`
+### `empty`
 
-Use the `#empty-state` slot to customize the empty state.
+Use the `#empty` slot to customize the empty state.
 
 ::component-example{class="grid"}
 ---
@@ -501,14 +501,16 @@ overflowClass: 'overflow-x-auto'
 const columns = [...]
 const people = [...]
 </script>
+
 <template>
   <UTable :rows="people" :columns="columns">
-    <template #empty-state>
-      <div class="flex items-center justify-center">
-        <span class="py-10">No Data.</span>
+    <template #empty>
+      <div class="flex flex-col items-center justify-center py-5">
+          <span>No people</span>
+          <UButton color="primary" label="Add People" size="sm" class="rounded-full mt-2"/>
       </div>
     </template>
-  </UTable>
+  </UTable> 
 </template>
 ```
 ::

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -36,12 +36,14 @@
 
         <tr v-if="emptyState && !rows.length">
           <td :colspan="columns.length">
-            <div :class="ui.emptyState.wrapper">
-              <UIcon v-if="emptyState.icon" :name="emptyState.icon" :class="ui.emptyState.icon" aria-hidden="true" />
-              <p :class="ui.emptyState.label">
-                {{ emptyState.label }}
-              </p>
-            </div>
+            <slot name="empty-state">
+              <div :class="ui.emptyState.wrapper">
+                <UIcon v-if="emptyState.icon" :name="emptyState.icon" :class="ui.emptyState.icon" aria-hidden="true" />
+                <p :class="ui.emptyState.label">
+                  {{ emptyState.label }}
+                </p>
+              </div>
+            </slot>
           </td>
         </tr>
       </tbody>

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -36,7 +36,7 @@
 
         <tr v-if="emptyState && !rows.length">
           <td :colspan="columns.length">
-            <slot name="empty-state">
+            <slot name="empty">
               <div :class="ui.emptyState.wrapper">
                 <UIcon v-if="emptyState.icon" :name="emptyState.icon" :class="ui.emptyState.icon" aria-hidden="true" />
                 <p :class="ui.emptyState.label">

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -36,7 +36,7 @@
 
         <tr v-if="emptyState && !rows.length">
           <td :colspan="columns.length">
-            <slot name="empty">
+            <slot name="empty-state">
               <div :class="ui.emptyState.wrapper">
                 <UIcon v-if="emptyState.icon" :name="emptyState.icon" :class="ui.emptyState.icon" aria-hidden="true" />
                 <p :class="ui.emptyState.label">


### PR DESCRIPTION
This feature allows for customizable content, including custom text, images, or components, to create a meaningful and visually appealing message when the table is empty.