### PR TITLE
feat(components): support rounded style 💅 

### DIFF
--- a/docs/components/content/examples/ContextMenuExampleRounded.vue
+++ b/docs/components/content/examples/ContextMenuExampleRounded.vue
@@ -1,0 +1,43 @@
+<script setup>
+const { x, y } = useMouse()
+const { y: windowY } = useWindowScroll()
+
+const isOpen = ref(false)
+const virtualElement = ref({ getBoundingClientRect: () => ({}) })
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+
+function onContextMenu() {
+  const top = unref(y) - unref(windowY)
+  const left = unref(x)
+
+  virtualElement.value.getBoundingClientRect = () => ({
+    width: 0,
+    height: 0,
+    top,
+    left
+  })
+
+  isOpen.value = true
+}
+</script>
+
+<template>
+  <div class="w-full">
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <div class="w-full" @contextmenu.prevent="onContextMenu">
+      <Placeholder class="h-96 select-none w-full flex items-center justify-center">
+        Right click here
+      </Placeholder>
+
+      <UContextMenu v-model="isOpen" :virtual-element="virtualElement" :rounded="rounded">
+        <div class="p-4">
+          Menu
+        </div>
+      </UContextMenu>
+    </div>
+  </div>
+</template>

--- a/docs/components/content/examples/DropdownExampleRounded.vue
+++ b/docs/components/content/examples/DropdownExampleRounded.vue
@@ -1,0 +1,25 @@
+<script setup>
+const items = [
+  [{
+    label: 'Profile',
+    avatar: {
+      src: 'https://avatars.githubusercontent.com/u/739984?v=4'
+    }
+  }]
+]
+
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UDropdown :items="items" mode="hover" :popper="{ placement: 'bottom-start' }" :rounded="rounded">
+      <UButton color="white" label="Options" trailing-icon="i-heroicons-chevron-down-20-solid" />
+    </UDropdown>
+  </div>
+</template>

--- a/docs/components/content/examples/ModalExampleRounded.vue
+++ b/docs/components/content/examples/ModalExampleRounded.vue
@@ -1,0 +1,21 @@
+<script setup>
+const isOpen = ref(false)
+const rounded = ref('lg');
+const roundedOptions = [ 'none','sm','rounded','md','lg','xl','2xl','3xl','full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded">
+      <USelect v-model="rounded" :options="roundedOptions"  />
+    </UFormGroup>
+
+    <UButton label="Open" @click="isOpen = true" class="mt-4" />
+
+    <UModal v-model="isOpen" :rounded="rounded">
+      <div class="p-4">
+        <Placeholder class="h-48" />
+      </div>
+    </UModal>
+  </div>
+</template>

--- a/docs/components/content/examples/NotificationExampleRounded.vue
+++ b/docs/components/content/examples/NotificationExampleRounded.vue
@@ -1,0 +1,15 @@
+<script setup>
+const toast = useToast()
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UButton label="Show toast" @click="toast.add({ title: 'Hello world!' , rounded})" />
+  </div>
+</template>

--- a/docs/components/content/examples/PopoverExampleRounded.vue
+++ b/docs/components/content/examples/PopoverExampleRounded.vue
@@ -1,0 +1,22 @@
+<script setup>
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UPopover :rounded="rounded">
+      <UButton color="white" label="Open" trailing-icon="i-heroicons-chevron-down-20-solid" />
+
+      <template #panel>
+        <div class="p-4">
+          <Placeholder class="h-20 w-48" />
+        </div>
+      </template>
+    </UPopover>
+  </div>
+</template>

--- a/docs/components/content/examples/SlideoverExampleRounded.vue
+++ b/docs/components/content/examples/SlideoverExampleRounded.vue
@@ -1,0 +1,36 @@
+<script setup>
+const isOpen = ref(false)
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UButton label="Open" @click="isOpen = true" />
+
+    <USlideover v-model="isOpen" :rounded="rounded">
+      <div class="p-4 sm:p-6 flex flex-col flex-1 gap-4 sm:gap-6">
+        <div class="flex items-center justify-between">
+          <h2 class="font-semibold text-gray-900 dark:text-white">
+            Title
+          </h2>
+
+          <UButton
+            icon="i-heroicons-x-mark-20-solid"
+            color="gray"
+            variant="link"
+            size="md"
+            :padded="false"
+            @click="isOpen = false"
+          />
+        </div>
+
+        <Placeholder class="flex-1 w-full" />
+      </div>
+    </USlideover>
+  </div>
+</template>

--- a/docs/components/content/examples/TooltipExampleRounded.vue
+++ b/docs/components/content/examples/TooltipExampleRounded.vue
@@ -1,0 +1,16 @@
+<script setup>
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UTooltip text="Tooltip example" :shortcuts="['⌘', 'O']" :rounded="rounded">
+      <UButton color="gray" label="Hover me" />
+    </UTooltip>
+  </div>
+</template>

--- a/docs/content/2.elements/1.avatar.md
+++ b/docs/content/2.elements/1.avatar.md
@@ -27,6 +27,20 @@ baseProps:
 ---
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Avatar.
+
+::component-card
+---
+props:
+  rounded: 'sm'
+baseProps:
+  src: 'https://avatars.githubusercontent.com/u/739984?v=4'
+  alt: 'Avatar'
+---
+::
+
 ### Chip
 
 Use the `chip-color` and `chip-position` props to display a chip on the Avatar.

--- a/docs/content/2.elements/2.badge.md
+++ b/docs/content/2.elements/2.badge.md
@@ -51,6 +51,19 @@ props:
 Badge
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Badge.
+
+::component-card
+---
+props:
+  rounded: 'md'
+---
+
+Badge
+::
+
 ## Props
 
 :component-props

--- a/docs/content/2.elements/3.button.md
+++ b/docs/content/2.elements/3.button.md
@@ -109,6 +109,19 @@ props:
 Button
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Button.
+
+::component-card
+---
+props:
+  rounded: 'md'
+---
+
+Button
+::
+
 ### Icon
 
 Use any icon from [Iconify](https://icones.js.org) by setting the `icon` prop by using this pattern: `i-{collection_name}-{icon_name}`.

--- a/docs/content/2.elements/4.dropdown.md
+++ b/docs/content/2.elements/4.dropdown.md
@@ -95,6 +95,38 @@ const items = [
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Dropdown.
+
+::component-example
+#default
+:dropdown-example-rounded
+
+#code
+```vue
+<script setup>
+const items = [...]
+
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UDropdown :items="items" mode="hover" :popper="{ placement: 'bottom-start' }" :rounded="rounded">
+      <UButton color="white" label="Options" trailing-icon="i-heroicons-chevron-down-20-solid" />
+    </UDropdown>
+  </div>
+</template>
+
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/2.elements/6.kbd.md
+++ b/docs/content/2.elements/6.kbd.md
@@ -62,6 +62,20 @@ code: 'U'
 U
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Kbd.
+
+::component-card
+---
+props:
+  rounded: 'sm'
+code: 'U'
+---
+
+U
+::
+
 ## Props
 
 :component-props

--- a/docs/content/3.forms/1.input.md
+++ b/docs/content/3.forms/1.input.md
@@ -72,6 +72,19 @@ props:
 ---
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Button.
+
+::component-card
+---
+baseProps:
+  name: 'input'
+props:
+  rounded: 'md'
+---
+::
+
 ### Placeholder
 
 Use the `placeholder` prop to set a placeholder text.

--- a/docs/content/3.forms/2.textarea.md
+++ b/docs/content/3.forms/2.textarea.md
@@ -72,6 +72,19 @@ props:
 ---
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Button.
+
+::component-card
+---
+baseProps:
+  name: 'input'
+props:
+  rounded: 'md'
+---
+::
+
 ### Placeholder
 
 Use the `placeholder` prop to set a placeholder text.

--- a/docs/content/3.forms/3.select.md
+++ b/docs/content/3.forms/3.select.md
@@ -95,6 +95,19 @@ props:
 ---
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Button.
+
+::component-card
+---
+baseProps:
+  name: 'input'
+props:
+  rounded: 'md'
+---
+::
+
 ### Placeholder
 
 Use the `placeholder` prop to set a placeholder text.

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -8,7 +8,7 @@ headlessui:
 
 ## Usage
 
-The SelectMenu component renders by default a [Select](/forms/select) component and is based on the `ui.select` preset. You can use most of the Select props to configure the display if you don't want to override the default slot such as [color](/forms/select#style), [variant](/forms/select#style), [size](/forms/select#size), [placeholder](/forms/select#placeholder), [icon](/forms/select#icon), [disabled](/forms/select#disabled), etc.
+The SelectMenu component renders by default a [Select](/forms/select) component and is based on the `ui.select` preset. You can use most of the Select props to configure the display if you don't want to override the default slot such as [color](/forms/select#style), [variant](/forms/select#style), [size](/forms/select#size), [rounded](/forms/select#rounded), [placeholder](/forms/select#placeholder), [icon](/forms/select#icon), [disabled](/forms/select#disabled), etc.
 
 ### Options
 

--- a/docs/content/6.overlays/1.modal.md
+++ b/docs/content/6.overlays/1.modal.md
@@ -64,6 +64,42 @@ const isOpen = ref(false)
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Modal.
+
+::component-example
+#default
+:modal-example-rounded
+
+#code
+```vue
+<script setup>
+const isOpen = ref(false)
+
+const rounded = ref('lg');
+
+const roundedOptions = [ 'none','sm','rounded','md','lg','xl','2xl','3xl','full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded">
+      <USelect v-model="rounded" :options="roundedOptions"  />
+    </UFormGroup>
+
+    <UButton label="Open" @click="isOpen = true" class="mt-4" />
+
+    <UModal v-model="isOpen" :rounded="rounded">
+      <div class="p-4">
+        <Placeholder class="h-48" />
+      </div>
+    </UModal>
+  </div>
+</template>
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/2.slideover.md
+++ b/docs/content/6.overlays/2.slideover.md
@@ -29,6 +29,41 @@ const isOpen = ref(false)
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Slideover.
+
+::component-example
+#default
+:slideover-example-rounded
+
+#code
+```vue
+<script setup>
+const isOpen = ref(false)
+
+const rounded = ref('lg');
+
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UButton label="Open" @click="isOpen = true" />
+
+    <USlideover v-model="isOpen" :rounded="rounded">
+      <!-- Content -->
+    </USlideover>
+  </div>
+</template>
+
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/3.popover.md
+++ b/docs/content/6.overlays/3.popover.md
@@ -25,6 +25,40 @@ headlessui:
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Popover.
+
+::component-example
+#default
+:popover-example-rounded
+
+#code
+```vue
+<script setup>
+const rounded = ref('lg');
+
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div class="flex flex-col">
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UPopover :rounded="rounded">
+      <UButton color="white" label="Open" trailing-icon="i-heroicons-chevron-down-20-solid" />
+
+      <template #panel>
+        <!-- Content -->
+      </template>
+    </UPopover>
+  </div>
+</template>
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/4.tooltip.md
+++ b/docs/content/6.overlays/4.tooltip.md
@@ -18,6 +18,34 @@ description: Display content that appears on hover next to an element.
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Tooltip.
+
+::component-example
+#default
+:tooltip-example-rounded
+
+#code
+```vue
+<script setup>
+const toast = useToast()
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+</script>
+
+<template>
+  <div>
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <UButton label="Show toast" @click="toast.add({ title: 'Hello world!' , rounded })" />
+  </div>
+</template>
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/5.context-menu.md
+++ b/docs/content/6.overlays/5.context-menu.md
@@ -42,6 +42,46 @@ function onContextMenu () {
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Context Menu.
+
+::component-example
+#default
+:context-menu-example-rounded
+
+#code
+```vue
+<script setup>
+const { x, y } = useMouse()
+const { y: windowY } = useWindowScroll()
+
+const isOpen = ref(false)
+const virtualElement = ref({ getBoundingClientRect: () => ({}) })
+
+const rounded = ref('lg');
+const roundedOptions = ['none', 'sm', 'rounded', 'md', 'lg', 'xl', '2xl', '3xl', 'full'];
+
+function onContextMenu() {...}
+</script>
+
+<template>
+  <div class="w-full">
+    <UFormGroup name="rounded" label="rounded" class="mb-4">
+      <USelect v-model="rounded" :options="roundedOptions" />
+    </UFormGroup>
+
+    <div class="w-full" @contextmenu.prevent="onContextMenu">
+      <UContextMenu v-model="isOpen" :virtual-element="virtualElement" :rounded="rounded">
+        <!-- Content -->
+      </UContextMenu>
+    </div>
+  </div>
+</template>
+
+```
+::
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/6.notification.md
+++ b/docs/content/6.overlays/6.notification.md
@@ -139,6 +139,43 @@ excludedProps:
 ---
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Notification.
+
+::component-card
+---
+baseProps:
+  id: 3
+  timeout: 0
+  title: 'Notification'
+props:
+  icon: 'i-heroicons-check-circle'
+  description: 'This is a notification.'
+  rounded: 'lg'
+excludedProps:
+  - icon
+  - description
+---
+::
+
+<br />
+
+::component-example
+#default
+:notification-example-rounded
+#code
+```vue
+<script setup>
+const toast = useToast()
+</script>
+
+<template>
+  <UButton label="Show toast" @click="toast.add({ title: 'Hello world!' })" />
+</template>
+```
+::
+
 ### Click
 
 Use the `click` prop to execute a function when the Notification is clicked.

--- a/docs/content/7.layout/1.card.md
+++ b/docs/content/7.layout/1.card.md
@@ -23,6 +23,20 @@ description: Display a card for content with a header, body and footer.
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Card.
+
+::component-card
+---
+props:
+  rounded: 'lg'
+code: 'U'
+---
+
+Card
+::
+
 ## Props
 
 :component-props

--- a/docs/content/7.layout/3.skeleton.md
+++ b/docs/content/7.layout/3.skeleton.md
@@ -25,6 +25,22 @@ Use to show a placeholder while content is loading.
 ```
 ::
 
+### Rounded
+
+Use the `rounded` prop to change the border radius of the Skeleton.
+
+::component-card
+---
+props:
+  rounded: 'md'
+  class: 'h-4 w-[250px]'
+excludedProps:
+  class
+---
+
+Skeleton
+::
+
 ## Props
 
 :component-props

--- a/src/runtime/app.config.ts
+++ b/src/runtime/app.config.ts
@@ -52,7 +52,17 @@ const table = {
 const avatar = {
   wrapper: 'relative inline-flex items-center justify-center',
   background: 'bg-gray-100 dark:bg-gray-800',
-  rounded: 'rounded-full',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   placeholder: 'font-medium leading-none text-gray-900 dark:text-white truncate',
   size: {
     '3xs': 'h-4 w-4 text-[8px]',
@@ -88,6 +98,7 @@ const avatar = {
   },
   default: {
     size: 'sm',
+    rounded: 'full',
     chipColor: null,
     chipPosition: 'top-right'
   }
@@ -101,7 +112,17 @@ const avatarGroup = {
 
 const badge = {
   base: 'inline-flex items-center',
-  rounded: 'rounded-md',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   font: 'font-medium',
   size: {
     xs: 'text-xs px-1.5 py-0.5',
@@ -115,6 +136,7 @@ const badge = {
   },
   default: {
     size: 'sm',
+    rounded: 'md',
     variant: 'solid',
     color: 'primary'
   }
@@ -123,7 +145,17 @@ const badge = {
 const button = {
   base: 'focus:outline-none focus-visible:outline-0 disabled:cursor-not-allowed disabled:opacity-75 flex-shrink-0',
   font: 'font-medium',
-  rounded: 'rounded-md',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   size: {
     '2xs': 'text-xs',
     xs: 'text-xs',
@@ -193,6 +225,7 @@ const button = {
     size: 'sm',
     variant: 'solid',
     color: 'primary',
+    rounded: 'md',
     loadingIcon: 'i-heroicons-arrow-path-20-solid'
   }
 }
@@ -209,7 +242,17 @@ const dropdown = {
   width: 'w-48',
   background: 'bg-white dark:bg-gray-800',
   shadow: 'shadow-lg',
-  rounded: 'rounded-md',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   ring: 'ring-1 ring-gray-200 dark:ring-gray-700',
   base: 'focus:outline-none',
   divide: 'divide-y divide-gray-200 dark:divide-gray-700',
@@ -244,6 +287,9 @@ const dropdown = {
   popper: {
     placement: 'bottom-end',
     strategy: 'fixed'
+  },
+  default: {
+    rounded: 'md',
   }
 }
 
@@ -255,12 +301,23 @@ const kbd = {
     sm: 'h-5 min-w-[20px] text-[11px]',
     md: 'h-6 min-w-[24px] text-[12px]'
   },
-  rounded: 'rounded',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   font: 'font-medium font-sans',
   background: 'bg-gray-100 dark:bg-gray-800',
   ring: 'ring-1 ring-gray-300 dark:ring-gray-700 ring-inset',
   default: {
-    size: 'sm'
+    size: 'sm',
+    rounded: 'rounded',
   }
 }
 
@@ -269,7 +326,6 @@ const kbd = {
 const input = {
   wrapper: 'relative',
   base: 'relative block w-full disabled:cursor-not-allowed disabled:opacity-75 focus:outline-none border-0',
-  rounded: 'rounded-md',
   placeholder: 'placeholder-gray-400 dark:placeholder-gray-500',
   custom: '',
   size: {
@@ -279,6 +335,17 @@ const input = {
     md: 'text-sm',
     lg: 'text-sm',
     xl: 'text-base'
+  },
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
   },
   gap: {
     '2xs': 'gap-x-1',
@@ -366,6 +433,7 @@ const input = {
   },
   default: {
     size: 'sm',
+    rounded: 'md',
     color: 'white',
     variant: 'outline',
     loadingIcon: 'i-heroicons-arrow-path-20-solid'
@@ -390,6 +458,7 @@ const textarea = {
   ...input,
   default: {
     size: 'sm',
+    rounded: 'md',
     color: 'white',
     variant: 'outline',
   }
@@ -400,6 +469,7 @@ const select = {
   placeholder: 'text-gray-900 dark:text-white',
   default: {
     size: 'sm',
+    rounded: 'md',
     color: 'white',
     variant: 'outline',
     loadingIcon: 'i-heroicons-arrow-path-20-solid',
@@ -415,7 +485,6 @@ const selectMenu = {
   base: 'relative focus:outline-none overflow-y-auto scroll-py-1',
   background: 'bg-white dark:bg-gray-800',
   shadow: 'shadow-lg',
-  rounded: 'rounded-md',
   padding: 'p-1',
   ring: 'ring-1 ring-gray-200 dark:ring-gray-700',
   input: 'block w-[calc(100%+0.5rem)] focus:ring-transparent text-sm px-3 py-1.5 text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 border-0 border-b border-gray-200 dark:border-gray-700 focus:border-inherit sticky -top-1 -mt-1 mb-1 -mx-1 z-10 placeholder-gray-400 dark:placeholder-gray-500',
@@ -504,7 +573,17 @@ const card = {
   background: 'bg-white dark:bg-gray-900',
   divide: 'divide-y divide-gray-200 dark:divide-gray-800',
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
-  rounded: 'rounded-lg',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   shadow: 'shadow',
   body: {
     base: '',
@@ -520,6 +599,9 @@ const card = {
     base: '',
     background: '',
     padding: 'px-4 py-4 sm:px-6'
+  },
+  default: {
+    rounded: 'lg',
   }
 }
 
@@ -530,9 +612,22 @@ const container = {
 }
 
 const skeleton = {
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   base: 'animate-pulse',
   background: 'bg-gray-100 dark:bg-gray-800',
-  rounded: 'rounded-md'
+  default: {
+    rounded: 'md',
+  }
 }
 
 // Navigation
@@ -543,7 +638,6 @@ const verticalNavigation = {
   ring: 'focus-visible:ring-inset focus-visible:ring-2 focus-visible:ring-primary-500 dark:focus-visible:ring-primary-400',
   padding: 'px-3 py-1.5',
   width: 'w-full',
-  rounded: 'rounded-md',
   font: 'font-medium',
   size: 'text-sm',
   active: 'text-gray-900 dark:text-white before:bg-gray-100 dark:before:bg-gray-800',
@@ -655,7 +749,17 @@ const modal = {
   },
   background: 'bg-white dark:bg-gray-900',
   ring: '',
-  rounded: 'rounded-lg',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   shadow: 'shadow-xl',
   width: 'sm:max-w-lg',
   height: '',
@@ -666,6 +770,9 @@ const modal = {
     leave: 'ease-in duration-200',
     leaveFrom: 'opacity-100 translate-y-0 sm:scale-100',
     leaveTo: 'opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95'
+  },
+  default: {
+    rounded: 'lg',
   }
 }
 
@@ -686,13 +793,26 @@ const slideover = {
   base: 'relative flex-1 flex flex-col w-full focus:outline-none',
   background: 'bg-white dark:bg-gray-900',
   ring: '',
-  rounded: '',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   padding: '',
   shadow: 'shadow-xl',
   width: 'w-screen max-w-md',
   transition: {
     enter: 'transform transition ease-in-out duration-300',
     leave: 'transform transition ease-in-out duration-200'
+  },
+  default: {
+    rounded: 'md',
   }
 }
 
@@ -702,7 +822,17 @@ const tooltip = {
   width: 'max-w-xs',
   background: 'bg-white dark:bg-gray-900',
   shadow: 'shadow',
-  rounded: 'rounded',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
   base: 'invisible lg:visible h-6 px-2 py-1 text-xs font-normal truncate',
   shortcuts: 'hidden md:inline-flex flex-shrink-0 gap-0.5',
@@ -716,6 +846,9 @@ const tooltip = {
   },
   popper: {
     strategy: 'fixed'
+  },
+  default: {
+    rounded: 'rounded',
   }
 }
 
@@ -725,7 +858,17 @@ const popover = {
   width: '',
   background: 'bg-white dark:bg-gray-900',
   shadow: 'shadow-lg',
-  rounded: 'rounded-md',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
   base: 'overflow-hidden focus:outline-none',
   transition: {
@@ -738,6 +881,9 @@ const popover = {
   },
   popper: {
     strategy: 'fixed'
+  },
+  default: {
+    rounded: 'md',
   }
 }
 
@@ -747,7 +893,17 @@ const contextMenu = {
   width: '',
   background: 'bg-white dark:bg-gray-900',
   shadow: 'shadow-lg',
-  rounded: 'rounded-md',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
   base: 'overflow-hidden focus:outline-none',
   transition: {
@@ -761,6 +917,9 @@ const contextMenu = {
   popper: {
     placement: 'bottom-start',
     scroll: false
+  },
+  default: {
+    rounded: 'md',
   }
 }
 
@@ -771,7 +930,17 @@ const notification = {
   description: 'mt-1 text-sm leading-5 text-gray-500 dark:text-gray-400',
   background: 'bg-white dark:bg-gray-900',
   shadow: 'shadow-lg',
-  rounded: 'rounded-lg',
+  rounded: {
+    none: 'rounded-none',
+    sm: 'rounded-sm',
+    rounded:'rounded',
+    md: 'rounded-md',
+    lg: 'rounded-lg',
+    xl: 'rounded-xl',
+    '2xl': 'rounded-2xl',
+    '3xl': 'rounded-3xl',
+    full: 'rounded-full'
+  },
   padding: 'p-4',
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
   icon: {
@@ -796,6 +965,7 @@ const notification = {
   },
   default: {
     color: 'primary',
+    rounded: 'lg',
     icon: null,
     closeButton: {
       icon: 'i-heroicons-x-mark-20-solid',

--- a/src/runtime/components/elements/Avatar.vue
+++ b/src/runtime/components/elements/Avatar.vue
@@ -41,6 +41,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.avatar.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.avatar.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.avatar.rounded).includes(value)
+      }
+    },
     chipColor: {
       type: String,
       default: () => appConfig.ui.avatar.default.chipColor,
@@ -70,14 +77,14 @@ export default defineComponent({
       return classNames(
         ui.value.wrapper,
         ui.value.background,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.size[props.size]
       )
     })
 
     const avatarClass = computed(() => {
       return classNames(
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.size[props.size]
       )
     })

--- a/src/runtime/components/elements/Badge.vue
+++ b/src/runtime/components/elements/Badge.vue
@@ -25,6 +25,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.badge.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.badge.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.badge.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.badge.default.color,
@@ -63,7 +70,7 @@ export default defineComponent({
       return classNames(
         ui.value.base,
         ui.value.font,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.size[props.size],
         variant?.replaceAll('{color}', props.color)
       )

--- a/src/runtime/components/elements/Button.vue
+++ b/src/runtime/components/elements/Button.vue
@@ -73,6 +73,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.button.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.button.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.button.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.button.default.color,
@@ -179,7 +186,7 @@ export default defineComponent({
       return classNames(
         ui.value.base,
         ui.value.font,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.size[props.size],
         ui.value.gap[props.size],
         props.padded && ui.value[isSquare.value ? 'square' : 'padding'][props.size],

--- a/src/runtime/components/elements/Kbd.vue
+++ b/src/runtime/components/elements/Kbd.vue
@@ -1,5 +1,5 @@
 <template>
-  <kbd :class="[ui.base, ui.size[size], ui.padding, ui.rounded, ui.font, ui.background, ui.ring]">
+  <kbd :class="[ui.base, ui.size[size], ui.padding, ui.rounded[rounded], ui.font, ui.background, ui.ring]">
     <slot>{{ value }}</slot>
   </kbd>
 </template>
@@ -26,6 +26,13 @@ export default defineComponent({
       default: () => appConfig.ui.kbd.default.size,
       validator (value: string) {
         return Object.keys(appConfig.ui.kbd.size).includes(value)
+      }
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.kbd.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.kbd.rounded).includes(value)
       }
     },
     ui: {

--- a/src/runtime/components/forms/Input.vue
+++ b/src/runtime/components/forms/Input.vue
@@ -130,6 +130,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.input.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.input.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.input.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.input.default.color,
@@ -182,7 +189,7 @@ export default defineComponent({
 
       return classNames(
         ui.value.base,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.placeholder,
         ui.value.size[props.size],
         props.padded ? ui.value.padding[props.size] : 'p-0',

--- a/src/runtime/components/forms/Select.vue
+++ b/src/runtime/components/forms/Select.vue
@@ -132,6 +132,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.select.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.select.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.select.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.select.default.color,
@@ -230,7 +237,7 @@ export default defineComponent({
 
       return classNames(
         ui.value.base,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.size[props.size],
         props.padded ? ui.value.padding[props.size] : 'p-0',
         variant?.replaceAll('{color}', props.color),

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -234,6 +234,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.select.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.select.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.select.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.select.default.color,
@@ -292,7 +299,7 @@ export default defineComponent({
 
       return classNames(
         uiSelect.value.base,
-        uiSelect.value.rounded,
+        uiSelect.value.rounded[props.rounded],
         'text-left cursor-default',
         uiSelect.value.size[props.size],
         uiSelect.value.gap[props.size],

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -83,6 +83,13 @@ export default defineComponent({
         return Object.keys(appConfig.ui.textarea.size).includes(value)
       }
     },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.textarea.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.textarea.rounded).includes(value)
+      }
+    },
     color: {
       type: String,
       default: () => appConfig.ui.textarea.default.color,
@@ -164,7 +171,7 @@ export default defineComponent({
 
       return classNames(
         ui.value.base,
-        ui.value.rounded,
+        ui.value.rounded[props.rounded],
         ui.value.placeholder,
         ui.value.size[props.size],
         props.padded ? ui.value.padding[props.size] : 'p-0',

--- a/src/runtime/components/layout/Card.vue
+++ b/src/runtime/components/layout/Card.vue
@@ -1,7 +1,7 @@
 <template>
   <component
     :is="$attrs.onSubmit ? 'form': as"
-    :class="[ui.base, ui.rounded, ui.divide, ui.ring, ui.shadow, ui.background]"
+    :class="[ui.base, ui.rounded[rounded], ui.divide, ui.ring, ui.shadow, ui.background]"
     v-bind="$attrs"
   >
     <div v-if="$slots.header" :class="[ui.header.base, ui.header.padding, ui.header.background]">
@@ -33,6 +33,13 @@ export default defineComponent({
     as: {
       type: String,
       default: 'div'
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.card.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.card.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.card>>,

--- a/src/runtime/components/layout/Skeleton.vue
+++ b/src/runtime/components/layout/Skeleton.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[ui.base, ui.background, ui.rounded]" />
+  <div :class="[ui.base, ui.background, ui.rounded[rounded]]" />
 </template>
 
 <script lang="ts">
@@ -15,6 +15,13 @@ import appConfig from '#build/app.config'
 
 export default defineComponent({
   props: {
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.skeleton.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.skeleton.rounded).includes(value)
+      }
+    },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.skeleton>>,
       default: () => appConfig.ui.skeleton

--- a/src/runtime/components/overlays/ContextMenu.vue
+++ b/src/runtime/components/overlays/ContextMenu.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isOpen" ref="container" :class="[ui.container, ui.width]">
     <transition appear v-bind="ui.transition">
-      <div :class="[ui.base, ui.ring, ui.rounded, ui.shadow, ui.background]">
+      <div :class="[ui.base, ui.ring, ui.rounded[rounded], ui.shadow, ui.background]">
         <slot />
       </div>
     </transition>
@@ -36,6 +36,13 @@ export default defineComponent({
     popper: {
       type: Object as PropType<PopperOptions>,
       default: () => ({})
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.contextMenu.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.contextMenu.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.contextMenu>>,

--- a/src/runtime/components/overlays/Modal.vue
+++ b/src/runtime/components/overlays/Modal.vue
@@ -8,7 +8,7 @@
       <div :class="ui.inner">
         <div :class="[ui.container, ui.padding]">
           <TransitionChild as="template" :appear="appear" v-bind="ui.transition">
-            <DialogPanel :class="[ui.base, ui.width, ui.height, ui.background, ui.ring, ui.rounded, ui.shadow]">
+            <DialogPanel :class="[ui.base, ui.width, ui.height, ui.background, ui.ring, ui.rounded[rounded], ui.shadow]">
               <slot />
             </DialogPanel>
           </TransitionChild>
@@ -54,6 +54,13 @@ export default defineComponent({
     transition: {
       type: Boolean,
       default: true
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.modal.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.modal.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.modal>>,

--- a/src/runtime/components/overlays/Notification.vue
+++ b/src/runtime/components/overlays/Notification.vue
@@ -1,7 +1,7 @@
 <template>
   <transition appear v-bind="ui.transition">
-    <div :class="[ui.wrapper, ui.background, ui.rounded, ui.shadow]" @mouseover="onMouseover" @mouseleave="onMouseleave">
-      <div :class="[ui.container, ui.rounded, ui.ring]">
+    <div :class="[ui.wrapper, ui.background, ui.rounded[rounded], ui.shadow]" @mouseover="onMouseover" @mouseleave="onMouseleave">
+      <div :class="[ui.container, ui.rounded[rounded], ui.ring]">
         <div :class="ui.padding">
           <div class="flex gap-3" :class="{ 'items-start': description, 'items-center': !description }">
             <UIcon v-if="icon" :name="icon" :class="iconClass" />
@@ -101,6 +101,13 @@ export default defineComponent({
       default: () => appConfig.ui.notification.default.color,
       validator (value: string) {
         return ['gray', ...appConfig.ui.colors].includes(value)
+      }
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.notification.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.notification.rounded).includes(value)
       }
     },
     ui: {

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -17,7 +17,7 @@
 
     <div v-if="open" ref="container" :class="[ui.container, ui.width]" @mouseover="onMouseOver">
       <transition appear v-bind="ui.transition">
-        <PopoverPanel :class="[ui.base, ui.background, ui.ring, ui.rounded, ui.shadow]" static>
+        <PopoverPanel :class="[ui.base, ui.background, ui.ring, ui.rounded[rounded], ui.shadow]" static>
           <slot name="panel" :open="open" :close="close" />
         </PopoverPanel>
       </transition>
@@ -68,6 +68,13 @@ export default defineComponent({
     popper: {
       type: Object as PropType<PopperOptions>,
       default: () => ({})
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.popover.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.popover.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.popover>>,

--- a/src/runtime/components/overlays/Slideover.vue
+++ b/src/runtime/components/overlays/Slideover.vue
@@ -6,7 +6,7 @@
       </TransitionChild>
 
       <TransitionChild as="template" :appear="appear" v-bind="transitionClass">
-        <DialogPanel :class="[ui.base, ui.width, ui.background, ui.ring, ui.padding]">
+        <DialogPanel :class="[ui.base, ui.width, ui.rounded[rounded], ui.background, ui.ring, ui.padding]">
           <slot />
         </DialogPanel>
       </TransitionChild>
@@ -55,6 +55,13 @@ export default defineComponent({
     transition: {
       type: Boolean,
       default: true
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.slideover.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.slideover.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.slideover>>,

--- a/src/runtime/components/overlays/Tooltip.vue
+++ b/src/runtime/components/overlays/Tooltip.vue
@@ -6,7 +6,7 @@
 
     <div v-if="open && !prevent" ref="container" :class="[ui.container, ui.width]">
       <transition appear v-bind="ui.transition">
-        <div :class="[ui.base, ui.background, ui.rounded, ui.shadow, ui.ring]">
+        <div :class="[ui.base, ui.background, ui.rounded[rounded], ui.shadow, ui.ring]">
           <slot name="text">
             {{ text }}
           </slot>
@@ -65,6 +65,13 @@ export default defineComponent({
     popper: {
       type: Object as PropType<PopperOptions>,
       default: () => ({})
+    },
+    rounded: {
+      type: String,
+      default: () => appConfig.ui.tooltip.default.rounded,
+      validator (value: string) {
+        return Object.keys(appConfig.ui.tooltip.rounded).includes(value)
+      }
     },
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.tooltip>>,

--- a/src/runtime/types/notification.d.ts
+++ b/src/runtime/types/notification.d.ts
@@ -7,16 +7,27 @@ export interface NotificationAction extends Partial<Button> {
 }
 
 export interface Notification {
-  id: string
-  title: string
-  description: string
-  icon?: string
-  avatar?: Partial<Avatar>
-  closeButton?: Partial<Button>
-  timeout: number
-  actions?: NotificationAction[]
-  click?: Function
-  callback?: Function
-  color?: string
-  ui?: Partial<typeof appConfig.ui.notification>
+  id: string;
+  title: string;
+  description: string;
+  icon?: string;
+  rounded?:
+    | 'none'
+    | 'sm'
+    | 'md'
+    | 'rounded'
+    | 'md'
+    | 'lg'
+    | 'xl'
+    | '2xl'
+    | '3xl'
+    | 'full';
+  avatar?: Partial<Avatar>;
+  closeButton?: Partial<Button>;
+  timeout: number;
+  actions?: NotificationAction[];
+  click?: Function;
+  callback?: Function;
+  color?: string;
+  ui?: Partial<typeof appConfig.ui.notification>;
 }


### PR DESCRIPTION
## 💅 Components with Rounded Styles

This PR introduces the ability to customize the **border radius** of the following components using the new rounded styles:

### ✨ Elements:

1. Avatar
2. Badge
3. Button
4. Dropdown
5. Kbd

### ✨ Forms:

1. Input
2. Textarea
3. Select
4. Select Menu

### ✨ Overlays:

1. Modal
2. Slideover
3. Popover
4. Tooltip
5. Context Menu
6. Notification

### ✨ Layout:

1. Card
2. Skeleton


## 💅 composables
1. useToast

The rounded styles provide the following options for the border radius:

- `none`: No border radius
- `sm`: Small border radius
- `rounded`: Default rounded border radius
- `md`: Medium rounded border radius
- `lg`: Large rounded border radius
- `xl`: Extra-large rounded border radius
- `2xl`: Double extra-large rounded border radius
- `3xl`: Triple extra-large rounded border radius
- `full`: Fully rounded border radius

❤️ Please review the changes in this PR and provide feedback.