### PR TITLE
fix(module): use `@tailwindcss/forms` class strategy

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -176,7 +176,7 @@ export default defineNuxtModule<ModuleOptions>({
       config: {
         darkMode: 'class',
         plugins: [
-          require('@tailwindcss/forms'),
+          require("@tailwindcss/forms")({ strategy: 'class' }),
           require('@tailwindcss/aspect-ratio'),
           require('@tailwindcss/typography'),
           require('@tailwindcss/container-queries')

--- a/src/runtime/components/forms/Checkbox.vue
+++ b/src/runtime/components/forms/Checkbox.vue
@@ -11,6 +11,7 @@
         :checked="checked"
         :indeterminate="indeterminate"
         type="checkbox"
+        class="form-checkbox"
         :class="[ui.base, ui.custom]"
         @focus="$emit('focus', $event)"
         @blur="$emit('blur', $event)"

--- a/src/runtime/components/forms/Input.vue
+++ b/src/runtime/components/forms/Input.vue
@@ -12,6 +12,7 @@
       :readonly="readonly"
       :autocomplete="autocomplete"
       :spellcheck="spellcheck"
+      class="form-input"
       :class="inputClass"
       @input="onInput"
       @focus="$emit('focus', $event)"

--- a/src/runtime/components/forms/Radio.vue
+++ b/src/runtime/components/forms/Radio.vue
@@ -9,6 +9,7 @@
         :value="value"
         :disabled="disabled"
         type="radio"
+        class="form-radio"
         :class="[ui.base, ui.custom]"
         @focus="$emit('focus', $event)"
         @blur="$emit('blur', $event)"

--- a/src/runtime/components/forms/Select.vue
+++ b/src/runtime/components/forms/Select.vue
@@ -6,6 +6,7 @@
       :value="modelValue"
       :required="required"
       :disabled="disabled || loading"
+      class="form-select"
       :class="selectClass"
       @input="onInput"
     >

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -10,6 +10,7 @@
       :disabled="disabled"
       :placeholder="placeholder"
       :autocomplete="autocomplete"
+      class="form-textarea"
       :class="textareaClass"
       @input="onInput"
       @focus="$emit('focus', $event)"


### PR DESCRIPTION
Resolves #270 

As mentioned in `@tailwindcss/forms` readme https://github.com/tailwindlabs/tailwindcss-forms#using-only-global-styles-or-only-classes:

> When using the class strategy, form elements are not styled globally, and instead must be styled using the generated form-{name} classes.

