### PR TITLE
fix(forms): precise type assertion for `onInput` event handler

### DIFF
--- a/src/runtime/components/forms/Input.vue
+++ b/src/runtime/components/forms/Input.vue
@@ -156,7 +156,7 @@ export default defineComponent({
     }
 
     const onInput = (event: InputEvent) => {
-      emit('update:modelValue', (event.target as any).value)
+      emit('update:modelValue', (event.target as HTMLInputElement).value)
     }
 
     onMounted(() => {

--- a/src/runtime/components/forms/Select.vue
+++ b/src/runtime/components/forms/Select.vue
@@ -173,7 +173,7 @@ export default defineComponent({
     const ui = computed<Partial<typeof appConfig.ui.select>>(() => defu({}, props.ui, appConfig.ui.select))
 
     const onInput = (event: InputEvent) => {
-      emit('update:modelValue', (event.target as any).value)
+      emit('update:modelValue', (event.target as HTMLInputElement).value)
     }
 
     const guessOptionValue = (option: any) => {

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -1,21 +1,8 @@
 <template>
   <div :class="ui.wrapper">
-    <textarea
-      :id="name"
-      ref="textarea"
-      :value="modelValue"
-      :name="name"
-      :rows="rows"
-      :required="required"
-      :disabled="disabled"
-      :placeholder="placeholder"
-      class="form-textarea"
-      :class="textareaClass"
-      v-bind="$attrs"
-      @input="onInput"
-      @focus="$emit('focus', $event)"
-      @blur="$emit('blur', $event)"
-    />
+    <textarea :id="name" ref="textarea" :value="modelValue" :name="name" :rows="rows" :required="required"
+      :disabled="disabled" :placeholder="placeholder" class="form-textarea" :class="textareaClass" v-bind="$attrs"
+      @input="onInput" @focus="$emit('focus', $event)" @blur="$emit('blur', $event)" />
   </div>
 </template>
 
@@ -77,21 +64,21 @@ export default defineComponent({
     size: {
       type: String,
       default: () => appConfig.ui.textarea.default.size,
-      validator (value: string) {
+      validator(value: string) {
         return Object.keys(appConfig.ui.textarea.size).includes(value)
       }
     },
     color: {
       type: String,
       default: () => appConfig.ui.textarea.default.color,
-      validator (value: string) {
+      validator(value: string) {
         return [...appConfig.ui.colors, ...Object.keys(appConfig.ui.textarea.color)].includes(value)
       }
     },
     variant: {
       type: String,
       default: () => appConfig.ui.textarea.default.variant,
-      validator (value: string) {
+      validator(value: string) {
         return [
           ...Object.keys(appConfig.ui.textarea.variant),
           ...Object.values(appConfig.ui.textarea.color).flatMap(value => Object.keys(value))
@@ -104,7 +91,7 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue', 'focus', 'blur'],
-  setup (props, { emit }) {
+  setup(props, { emit }) {
     const textarea = ref<HTMLTextAreaElement | null>(null)
 
     // TODO: Remove
@@ -142,8 +129,7 @@ export default defineComponent({
 
     const onInput = (event: InputEvent) => {
       autoResize()
-
-      emit('update:modelValue', (event.target as any).value)
+      emit('update:modelValue', (event.target as HTMLInputElement).value)
     }
 
     watch(() => props.modelValue, () => {

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -77,21 +77,21 @@ export default defineComponent({
     size: {
       type: String,
       default: () => appConfig.ui.textarea.default.size,
-      validator(value: string) {
+      validator (value: string) {
         return Object.keys(appConfig.ui.textarea.size).includes(value)
       }
     },
     color: {
       type: String,
       default: () => appConfig.ui.textarea.default.color,
-      validator(value: string) {
+      validator (value: string) {
         return [...appConfig.ui.colors, ...Object.keys(appConfig.ui.textarea.color)].includes(value)
       }
     },
     variant: {
       type: String,
       default: () => appConfig.ui.textarea.default.variant,
-      validator(value: string) {
+      validator (value: string) {
         return [
           ...Object.keys(appConfig.ui.textarea.variant),
           ...Object.values(appConfig.ui.textarea.color).flatMap(value => Object.keys(value))
@@ -104,7 +104,7 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue', 'focus', 'blur'],
-  setup(props, { emit }) {
+  setup (props, { emit }) {
     const textarea = ref<HTMLTextAreaElement | null>(null)
 
     // TODO: Remove
@@ -142,6 +142,7 @@ export default defineComponent({
 
     const onInput = (event: InputEvent) => {
       autoResize()
+
       emit('update:modelValue', (event.target as HTMLInputElement).value)
     }
 

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -1,8 +1,21 @@
 <template>
   <div :class="ui.wrapper">
-    <textarea :id="name" ref="textarea" :value="modelValue" :name="name" :rows="rows" :required="required"
-      :disabled="disabled" :placeholder="placeholder" class="form-textarea" :class="textareaClass" v-bind="$attrs"
-      @input="onInput" @focus="$emit('focus', $event)" @blur="$emit('blur', $event)" />
+    <textarea
+      :id="name"
+      ref="textarea"
+      :value="modelValue"
+      :name="name"
+      :rows="rows"
+      :required="required"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      class="form-textarea"
+      :class="textareaClass"
+      v-bind="$attrs"
+      @input="onInput"
+      @focus="$emit('focus', $event)"
+      @blur="$emit('blur', $event)"
+    />
   </div>
 </template>
 


### PR DESCRIPTION
This commit updates the onInput event handler code. The type assertion in the code has been modified to cast event.target as HTMLInputElement instead of any. By using the specific HTMLInputElement type, we ensure accurate type checking and maintain type safety throughout the codebase. The event handler still emits the 'update:modelValue' event and updates the model value based on the input element's value. This modification enhances code clarity and provides more precise typing, leading to better code quality.