### PR TITLE
feat(Accordion): add `multiple` prop and close others by default 

### DIFF
--- a/docs/components/content/examples/AccordionExampleBasic.vue
+++ b/docs/components/content/examples/AccordionExampleBasic.vue
@@ -30,5 +30,5 @@ const items = [{
 </script>
 
 <template>
-  <UAccordion :items="items" />
+  <UAccordion :items="items" multiple />
 </template>

--- a/docs/components/content/examples/AccordionExampleBasic.vue
+++ b/docs/components/content/examples/AccordionExampleBasic.vue
@@ -12,6 +12,7 @@ const items = [{
 }, {
   label: 'Theming',
   icon: 'i-heroicons-eye-dropper',
+  closeOthers: true,
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
 }, {
   label: 'Layouts',

--- a/docs/components/content/examples/AccordionExampleBasic.vue
+++ b/docs/components/content/examples/AccordionExampleBasic.vue
@@ -30,5 +30,5 @@ const items = [{
 </script>
 
 <template>
-  <UAccordion :items="items" multiple />
+  <UAccordion :items="items" />
 </template>

--- a/docs/components/content/examples/AccordionExampleBasic.vue
+++ b/docs/components/content/examples/AccordionExampleBasic.vue
@@ -12,7 +12,6 @@ const items = [{
 }, {
   label: 'Theming',
   icon: 'i-heroicons-eye-dropper',
-  closeOthers: true,
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
 }, {
   label: 'Layouts',

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -16,6 +16,7 @@ Pass an array to the `items` prop of the Accordion component. Each item can have
 - `content` - The content to display in the panel by default.
 - `disabled` - Determines whether the item is disabled or not.
 - `defaultOpen` - Determines whether the item is initially open or closed.
+- `closeOthers` - Determines whether the item click close others or not.
 
 ::component-example
 #default
@@ -34,7 +35,12 @@ const items = [{
   icon: 'i-heroicons-arrow-down-tray',
   disabled: true,
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
-}, ...]
+}, {
+  label: 'Theming',
+  icon: 'i-heroicons-eye-dropper',
+  closeOthers: true,
+  content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
+} ...]
 </script>
 
 <template>
@@ -125,6 +131,29 @@ baseProps:
       content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 props:
   defaultOpen: true
+excludedProps:
+  - defaultOpen
+---
+::
+
+### Close others
+
+Use the `close-others` prop to always close others when an item is opened.
+
+::component-card
+---
+baseProps:
+  items:
+    - label: "What is NuxtLabs UI?"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Getting Started"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Theming"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Components"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+props:
+  closeOthers: true
 excludedProps:
   - defaultOpen
 ---

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -16,7 +16,7 @@ Pass an array to the `items` prop of the Accordion component. Each item can have
 - `content` - The content to display in the panel by default.
 - `disabled` - Determines whether the item is disabled or not.
 - `defaultOpen` - Determines whether the item is initially open or closed.
-- `closeOthers` - Determines whether the item click close others or not.
+- `closeOthers` - Determines whether the item click close others or not. **It only works with multiple mode**. 
 
 ::component-example
 #default
@@ -44,7 +44,7 @@ const items = [{
 </script>
 
 <template>
-  <UAccordion :items="items" />
+  <UAccordion :items="items" multiple />
 </template>
 ```
 ::
@@ -136,9 +136,9 @@ excludedProps:
 ---
 ::
 
-### Close others
+### Multiple
 
-Use the `close-others` prop to always close others when an item is opened.
+Use the `multiple` prop to to allow multiple elements to be opened at the same time.
 
 ::component-card
 ---
@@ -153,7 +153,7 @@ baseProps:
     - label: "Components"
       content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 props:
-  closeOthers: true
+  multiple: true
 excludedProps:
   - defaultOpen
 ---

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -38,7 +38,6 @@ const items = [{
 }, {
   label: 'Theming',
   icon: 'i-heroicons-eye-dropper',
-  closeOthers: true,
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
 } ...]
 </script>
@@ -57,14 +56,14 @@ You can also pass any prop from the [Button](/elements/button) component directl
 ---
 baseProps:
   items:
-    - label: "1. What is NuxtLabs UI?"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "2. Getting Started"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "3. Theming"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "4. Components"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: '1. What is NuxtLabs UI?'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '2. Getting Started'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '3. Theming'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '4. Components'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
 props:
   color: 'primary'
   variant: 'soft'
@@ -96,14 +95,14 @@ You can also set them to `null` to hide the icons.
 ---
 baseProps:
   items:
-    - label: "1. What is NuxtLabs UI?"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "2. Getting Started"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "3. Theming"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "4. Components"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: '1. What is NuxtLabs UI?'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '2. Getting Started'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '3. Theming'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: '4. Components'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
 props:
   openIcon: 'i-heroicons-plus'
   closeIcon: 'i-heroicons-minus'
@@ -121,14 +120,14 @@ Use the `multiple` prop to to allow multiple elements to be opened at the same t
 ---
 baseProps:
   items:
-    - label: "What is NuxtLabs UI?"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Getting Started"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Theming"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Components"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: 'What is NuxtLabs UI?'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Getting Started'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Theming'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Components'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
 props:
   multiple: true
 excludedProps:
@@ -144,14 +143,14 @@ Use the `default-open` prop to open all items by default. Works better when the 
 ---
 baseProps:
   items:
-    - label: "What is NuxtLabs UI?"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Getting Started"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Theming"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Components"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: 'What is NuxtLabs UI?'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Getting Started'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Theming'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
+    - label: 'Components'
+      content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit'
 props:
   defaultOpen: true
   multiple: true

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -113,6 +113,29 @@ excludedProps:
 ---
 ::
 
+### Multiple
+
+Use the `multiple` prop to to allow multiple elements to be opened at the same time.
+
+::component-card
+---
+baseProps:
+  items:
+    - label: "What is NuxtLabs UI?"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Getting Started"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Theming"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+    - label: "Components"
+      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+props:
+  multiple: true
+excludedProps:
+  - defaultOpen
+---
+::
+
 ### Open
 
 Use the `default-open` prop to open all items by default. Works better when the `multiple` prop is set to `true`.
@@ -135,29 +158,6 @@ props:
 excludedProps:
   - defaultOpen
   - multiple
----
-::
-
-### Multiple
-
-Use the `multiple` prop to to allow multiple elements to be opened at the same time.
-
-::component-card
----
-baseProps:
-  items:
-    - label: "What is NuxtLabs UI?"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Getting Started"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Theming"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-    - label: "Components"
-      content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
-props:
-  multiple: true
-excludedProps:
-  - defaultOpen
 ---
 ::
 

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -35,11 +35,7 @@ const items = [{
   icon: 'i-heroicons-arrow-down-tray',
   disabled: true,
   content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
-}, {
-  label: 'Theming',
-  icon: 'i-heroicons-eye-dropper',
-  content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed neque elit, tristique placerat feugiat ac, facilisis vitae arcu. Proin eget egestas augue. Praesent ut sem nec arcu pellentesque aliquet. Duis dapibus diam vel metus tempus vulputate.'
-} ...]
+}, ...]
 </script>
 
 <template>

--- a/docs/content/2.elements/5.accordion.md
+++ b/docs/content/2.elements/5.accordion.md
@@ -16,7 +16,7 @@ Pass an array to the `items` prop of the Accordion component. Each item can have
 - `content` - The content to display in the panel by default.
 - `disabled` - Determines whether the item is disabled or not.
 - `defaultOpen` - Determines whether the item is initially open or closed.
-- `closeOthers` - Determines whether the item click close others or not. **It only works with multiple mode**. 
+- `closeOthers` - Determines whether the item click close others or not. **It only works with multiple mode**.
 
 ::component-example
 #default
@@ -44,7 +44,7 @@ const items = [{
 </script>
 
 <template>
-  <UAccordion :items="items" multiple />
+  <UAccordion :items="items" />
 </template>
 ```
 ::
@@ -115,7 +115,7 @@ excludedProps:
 
 ### Open
 
-Use the `default-open` prop to open all items by default.
+Use the `default-open` prop to open all items by default. Works better when the `multiple` prop is set to `true`.
 
 ::component-card
 ---
@@ -131,8 +131,10 @@ baseProps:
       content: "Lorem ipsum dolor sit amet, consectetur adipiscing elit"
 props:
   defaultOpen: true
+  multiple: true
 excludedProps:
   - defaultOpen
+  - multiple
 ---
 ::
 

--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -94,13 +94,13 @@ export default defineComponent({
 
     const uiButton = computed<Partial<typeof appConfig.ui.button>>(() => appConfig.ui.button)
 
-    const closesRefs = ref([])
+    const closesRefs = ref<Function[]>([])
 
-    function updateClosesRefs (close, index) {
+    function updateClosesRefs (close: Function, index: number) {
       closesRefs.value[index] = close
     }
 
-    function closeAll (itemIndex) {
+    function closeAll (itemIndex: number) {
       if (!props.items[itemIndex].closeOthers && !props.closeOthers) return
 
       closesRefs.value.forEach((close, index) => {
@@ -144,7 +144,7 @@ export default defineComponent({
       onEnter,
       onBeforeLeave,
       onAfterEnter,
-      onLeave,
+      onLeave
     }
   }
 })

--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -77,7 +77,7 @@ export default defineComponent({
       type: String,
       default: () => appConfig.ui.accordion.default.closeIcon
     },
-    closeOthers: {
+    multiple: {
       type: Boolean,
       default: false
     },
@@ -101,7 +101,7 @@ export default defineComponent({
     }
 
     function closeAll (itemIndex: number) {
-      if (!props.items[itemIndex].closeOthers && !props.closeOthers) return
+      if (!props.items[itemIndex].closeOthers && props.multiple) return
 
       closesRefs.value.forEach((close, index) => {
         if (index === itemIndex) return

--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="ui.wrapper">
     <HDisclosure v-for="(item, index) in items" v-slot="{ open, close }" :key="index" :default-open="defaultOpen || item.defaultOpen">
-      <HDisclosureButton as="template" :ref="() => updateClosesRefs(close, index)" :disabled="item.disabled">
+      <HDisclosureButton :ref="() => updateClosesRefs(close, index)" as="template" :disabled="item.disabled">
         <slot :item="item" :index="index" :open="open" :close="close">
           <UButton v-bind="{ ...omit(ui.default, ['openIcon', 'closeIcon']), ...$attrs, ...omit(item, ['slot', 'disabled', 'content', 'defaultOpen']) }" class="w-full" @click="closeAll(index)">
             <template #trailing>
@@ -88,11 +88,11 @@ export default defineComponent({
 
     const closesRefs = ref([])
 
-    function updateClosesRefs(close, index) {
+    function updateClosesRefs (close, index) {
       closesRefs.value[index] = close
     }
 
-    function closeAll(itemIndex) {
+    function closeAll (itemIndex) {
       if (!props.items[itemIndex].closeOthers && !props.closeOthers) return
 
       closesRefs.value.forEach((close, index) => {

--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -1,7 +1,7 @@
 <template>
   <div :class="ui.wrapper">
     <HDisclosure v-for="(item, index) in items" v-slot="{ open, close }" :key="index" :default-open="defaultOpen || item.defaultOpen">
-      <HDisclosureButton as="template" :disabled="item.disabled" :ref="() => updateClosesRefs(close, index)">
+      <HDisclosureButton as="template" :ref="() => updateClosesRefs(close, index)" :disabled="item.disabled">
         <slot :item="item" :index="index" :open="open" :close="close">
           <UButton v-bind="{ ...omit(ui.default, ['openIcon', 'closeIcon']), ...$attrs, ...omit(item, ['slot', 'disabled', 'content', 'defaultOpen']) }" class="w-full" @click="closeAll(index)">
             <template #trailing>
@@ -89,14 +89,14 @@ export default defineComponent({
     const closesRefs = ref([])
 
     function updateClosesRefs(close, index) {
-      closesRefs.value[index] = close;
+      closesRefs.value[index] = close
     }
 
     function closeAll(itemIndex) {
-      if (!props.items[itemIndex].closeOthers && !props.closeOthers) return;
+      if (!props.items[itemIndex].closeOthers && !props.closeOthers) return
 
       closesRefs.value.forEach((close, index) => {
-        if (index === itemIndex) return;
+        if (index === itemIndex) return
 
         close()
       })
@@ -109,7 +109,7 @@ export default defineComponent({
       omit,
       closeAll,
       closesRefs,
-      updateClosesRefs,
+      updateClosesRefs
     }
   }
 })

--- a/src/runtime/utils/StateEmitter.ts
+++ b/src/runtime/utils/StateEmitter.ts
@@ -1,0 +1,22 @@
+import { watch, defineComponent } from 'vue'
+
+export default defineComponent({
+  props: {
+    open: {
+      type: Boolean,
+      default: false
+    }
+  },
+  emits: ['open', 'close'],
+  setup (props, { emit }) {
+    watch(() => props.open, (value) => {
+      if (value) {
+        emit('open')
+      } else {
+        emit('close')
+      }
+    })
+
+    return () => {}
+  }
+})


### PR DESCRIPTION
Resolves #362 
Resolves #356

This PR adds to the `Accordion` component an additional mode of operation where you can customize the closing of panels when a specific list item is opened or global closing of panels whenever 1 list item is open.