### PR TITLE
fix(Range): progress style

### DIFF
--- a/src/runtime/components/forms/Range.vue
+++ b/src/runtime/components/forms/Range.vue
@@ -128,8 +128,11 @@ export default defineComponent({
     })
 
     const progressStyle = computed(() => {
+      const { modelValue, min, max } = props
+      const clampedValue = Math.max(min, Math.min(modelValue, max))
+      const relativeValue = (clampedValue - min) / (max - min)
       return {
-        width: `${(props.modelValue / props.max) * 100}%`
+        width: `${relativeValue * 100}%`
       }
     })
 


### PR DESCRIPTION
When specifying a non-zero value (including positive or negative numbers), the range progress bar style has issues, as shown on the left side of the following picture. The version on the right has been fixed.

<img width="1543" alt="image" src="https://github.com/nuxtlabs/ui/assets/5625783/2586812d-590a-4b9f-bfb1-932e6f36fd4c">
