### PR TITLE
docs: add `nuxt.config.ts` `ui` entry example

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -116,7 +116,7 @@ export default defineNuxtConfig({
     global: true,
     icons: ['mdi', 'simple-icons']
   }
-});
+})
 ```
 
 ## Edge

--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -105,7 +105,19 @@ You can also add the following to your `settings.json` to enable IntelliSense wh
 | `prefix`                 | `u`                    | Define the prefix of the imported components.    |
 | `global`                 | `false`                | Expose components globally.                      |
 | `icons`                  | `['heroicons']`        | Icon collections to load.                        |
-| `safelistColors`         | `['primary']`          | Force safelisting of colors.                     |
+| `safelistColors`         | `['primary']`          | Force safelisting of colors to need be purged.   |
+
+Configure options in your `nuxt.config.ts` as such:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxthq/ui'],
+  ui: {
+    global: true,
+    icons: ['mdi', 'simple-icons']
+  }
+});
+```
 
 ## Edge
 


### PR DESCRIPTION
Good to have an example of the "ui" key here. It's repeated later in the docs.