### PR TITLE
docs: explicit settings.json path

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -42,9 +42,9 @@ As this module installs [@nuxtjs/tailwindcss](https://tailwindcss.nuxtjs.org/) a
 
 If you're using VSCode, you can install the [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) extension to get autocompletion for the classes.
 
-You can read more on how to set it up on the [@nuxtjs/tailwindcss](https://tailwindcss.nuxtjs.org/tailwind/editor-support) module documentation, but to summarize, you'll need to add the following to your `settings.json`:
+You can read more on how to set it up on the [@nuxtjs/tailwindcss](https://tailwindcss.nuxtjs.org/tailwind/editor-support) module documentation, but to summarize, you'll need to add the following to your `.vscode/settings.json`:
 
-```json [settings.json]
+```json [.vscode/settings.json]
 {
   "files.associations": {
       "*.css": "tailwindcss"
@@ -67,17 +67,17 @@ export default <Partial<Config>> {
 }
 ```
 
-If you do so, you'll need to add the following to your `settings.json`:
+If you do so, you'll need to add the following to your `.vscode/settings.json`:
 
-```json [settings.json]
+```json [.vscode/settings.json]
 {
   "tailwindCSS.experimental.configFile": "tailwind.config.ts"
 }
 ```
 
-Also, the extension won't work when writing classes in your `app.config.ts` by default. You can add the following to your `settings.json` to fix this:
+Also, the extension won't work when writing classes in your `app.config.ts` by default. You can add the following to your `.vscode/settings.json` to fix this:
 
-```json [settings.json]
+```json [.vscode/settings.json]
 {
   "tailwindCSS.experimental.classRegex": [
     ["ui:\\s*{([^)]*)\\s*}", "[\"'`]([^\"'`]*).*?[\"'`]"]
@@ -85,9 +85,9 @@ Also, the extension won't work when writing classes in your `app.config.ts` by d
 }
 ```
 
-You can also add the following to your `settings.json` to enable IntelliSense when using the `ui` prop:
+You can also add the following to your `.vscode/settings.json` to enable IntelliSense when using the `ui` prop:
 
-```json [settings.json]
+```json [.vscode/settings.json]
 {
   "tailwindCSS.classAttributes": [
     "class",


### PR DESCRIPTION
Change all `settings.json` matches with ` .vscode/settings.json` to make it more explicit and clear like in [Nuxt Tailwind Docs](https://tailwindcss.nuxtjs.org/tailwind/editor-support)