### PR TITLE
docs(Select): disable single select options

### DIFF
--- a/docs/content/3.forms/3.select.md
+++ b/docs/content/3.forms/3.select.md
@@ -27,7 +27,9 @@ const country = ref(countries[0])
 ```
 ::
 
-When using objects, you can configure which field will be used for display through the `option-attribute` prop that defaults to `label` and which field will be used for comparison through the `value-attribute` prop that defaults to `value`.
+When using objects, you can configure which field will be used for display through the `option-attribute` prop that defaults to `label` and which field will be used for comparison through the `value-attribute` prop that defaults to `value`. 
+
+Adding a `disabled` key to the objects will control the disabled state of the option.
 
 ::component-example
 #default
@@ -41,7 +43,8 @@ const countries = [{
   value: 'US'
 }, {
   name: 'Canada',
-  value: 'CA'
+  value: 'CA',
+  disabled: true
 }, {
   name: 'Mexico',
   value: 'MX'
@@ -190,6 +193,8 @@ props:
   disabled: true
 ---
 ::
+
+Add a `disabled` key with a truthy value to the `options` array of object to disable a single option.
 
 ### Loading
 


### PR DESCRIPTION
Wanted to add this detail to the docs. I found it by chance passing the proper object into the options prop and thought it might be helpful to people searching the docs.