### PR TITLE
feat(SelectMenu): handle async search

### DIFF
--- a/docs/components/content/examples/SelectMenuExampleAsyncSearch.vue
+++ b/docs/components/content/examples/SelectMenuExampleAsyncSearch.vue
@@ -1,0 +1,21 @@
+<script setup>
+
+const asyncFunction = async (q) => {
+  const users = await $fetch('https://jsonplaceholder.typicode.com/users', { params: { q } })
+
+  return users.map(user => ({ id: user.id, label: user.name, suffix: user.email })).filter(Boolean)
+}
+
+const selected = ref([])
+</script>
+
+<template>
+  <USelectMenu
+    v-model="selected"
+    :search-function="asyncFunction"
+    searchable
+    placeholder="Search for a user..."
+    multiple
+    by="id"
+  />
+</template>

--- a/docs/components/content/examples/SelectMenuExampleAsyncSearch.vue
+++ b/docs/components/content/examples/SelectMenuExampleAsyncSearch.vue
@@ -1,6 +1,5 @@
 <script setup>
-
-const asyncFunction = async (q) => {
+const search = async (q) => {
   const users = await $fetch('https://jsonplaceholder.typicode.com/users', { params: { q } })
 
   return users.map(user => ({ id: user.id, label: user.name, suffix: user.email })).filter(Boolean)
@@ -12,8 +11,7 @@ const selected = ref([])
 <template>
   <USelectMenu
     v-model="selected"
-    :search-function="asyncFunction"
-    searchable
+    :searchable="search"
     placeholder="Search for a user..."
     multiple
     by="id"

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -149,6 +149,43 @@ props:
 ---
 ::
 
+### Async search
+
+The `searchFunction` prop enables you to customize the search behavior and filter options according to your needs. 
+
+It takes the value of the input as its first parameter to filter the search results based on what the user typed in the search input.
+
+You can adjust the debounce delay of the function by changing the `debounce` prop value.
+
+::component-example
+#default
+:select-menu-example-async-search{class="max-w-[12rem] w-full"}
+#code
+```vue
+<script setup>
+
+const asyncFunction = async (q) => {
+  const users = await $fetch('https://jsonplaceholder.typicode.com/users', { params: { q } })
+
+  return users.map(user => ({ id: user.id, label: user.name, suffix: user.email })).filter(Boolean)
+}
+
+const selected = ref([])
+</script>
+
+<template>
+  <USelectMenu
+    v-model="selected"
+    :search-function="asyncFunction"
+    searchable
+    placeholder="Search for a user..."
+    multiple
+    by="id"
+  />
+</template>
+```
+::
+
 ## Slots
 
 ### `label`

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -151,20 +151,18 @@ props:
 
 ### Async search
 
-The `searchFunction` prop enables you to customize the search behavior and filter options according to your needs. 
+Pass a function to the `searchable` prop to customize the search behavior and filter options according to your needs. The function will receive the query as its first argument and should return an array.
 
-It takes the value of the input as its first parameter to filter the search results based on what the user typed in the search input.
-
-You can adjust the debounce delay of the function by changing the `debounce` prop value.
+Use the `debounce` prop to adjust the delay of the function.
 
 ::component-example
 #default
 :select-menu-example-async-search{class="max-w-[12rem] w-full"}
+
 #code
 ```vue
 <script setup>
-
-const asyncFunction = async (q) => {
+const search = async (q) => {
   const users = await $fetch('https://jsonplaceholder.typicode.com/users', { params: { q } })
 
   return users.map(user => ({ id: user.id, label: user.name, suffix: user.email })).filter(Boolean)
@@ -176,8 +174,7 @@ const selected = ref([])
 <template>
   <USelectMenu
     v-model="selected"
-    :search-function="asyncFunction"
-    searchable
+    :searchable="search"
     placeholder="Search for a user..."
     multiple
     by="id"

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -220,16 +220,12 @@ export default defineComponent({
       default: false
     },
     searchable: {
-      type: Boolean,
+      type: [Boolean, Function] as PropType<boolean | ((query: string) => Promise<any[]> | any[])>,
       default: false
     },
     searchablePlaceholder: {
       type: String,
       default: 'Search...'
-    },
-    searchFunction: {
-      type: Function as PropType<(query: string) => Promise<any[]> | any[]>,
-      default: null
     },
     debounce: {
       type: Number,
@@ -382,7 +378,7 @@ export default defineComponent({
       )
     })
 
-    const debouncedSearch = typeof props.searchFunction === 'function' ? useDebounceFn(props.searchFunction, props.debounce) : undefined
+    const debouncedSearch = typeof props.searchable === 'function' ? useDebounceFn(props.searchable, props.debounce) : undefined
 
     const filteredOptions = computedAsync(async () => {
       if (props.searchable && debouncedSearch) {

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -129,6 +129,7 @@ import {
   ListboxOptions as HListboxOptions,
   ListboxOption as HListboxOption
 } from '@headlessui/vue'
+import { computedAsync, useDebounceFn } from '@vueuse/core'
 import { defu } from 'defu'
 import UIcon from '../elements/Icon.vue'
 import UAvatar from '../elements/Avatar.vue'
@@ -225,6 +226,14 @@ export default defineComponent({
     searchablePlaceholder: {
       type: String,
       default: 'Search...'
+    },
+    searchFunction: {
+      type: Function as PropType<(query: string) => Promise<any[]> | any[]>,
+      default: null
+    },
+    debounce: {
+      type: Number,
+      default: 200
     },
     creatable: {
       type: Boolean,
@@ -373,15 +382,23 @@ export default defineComponent({
       )
     })
 
-    const filteredOptions = computed(() =>
-      query.value === ''
-        ? props.options
-        : (props.options as any[]).filter((option: any) => {
-            return (props.searchAttributes?.length ? props.searchAttributes : [props.optionAttribute]).some((searchAttribute: any) => {
-              return typeof option === 'string' ? option.search(new RegExp(query.value, 'i')) !== -1 : (option[searchAttribute] && option[searchAttribute].search(new RegExp(query.value, 'i')) !== -1)
-            })
-          })
-    )
+    const debouncedSearch = typeof props.searchFunction === 'function' ? useDebounceFn(props.searchFunction, props.debounce) : undefined
+
+    const filteredOptions = computedAsync(async () => {
+      if (props.searchable && debouncedSearch) {
+        return await debouncedSearch(query.value)
+      }
+
+      if (query.value === '') {
+        return props.options
+      }
+
+      return (props.options as any[]).filter((option: any) => {
+        return (props.searchAttributes?.length ? props.searchAttributes : [props.optionAttribute]).some((searchAttribute: any) => {
+          return typeof option === 'string' ? option.search(new RegExp(query.value, 'i')) !== -1 : (option[searchAttribute] && option[searchAttribute].search(new RegExp(query.value, 'i')) !== -1)
+        })
+      })
+    })
 
     const queryOption = computed(() => {
       return query.value === '' ? null : { [props.optionAttribute]: query.value }


### PR DESCRIPTION
Resolves #384 

Add the possibility to set a `searchFunction` as prop to allow the user to have complete control of the way options are filtered.

This function can be either synchronous or asynchronous.

Let me know what you think 🙂

<img width="771" alt="image" src="https://github.com/nuxtlabs/ui/assets/6144489/bbb4e433-3dd1-4e72-8d6d-935e9ee7ebaf">
