### PR TITLE
fix the select tag style and rectify import statements

### DIFF
--- a/src/runtime/components/forms/Select.vue
+++ b/src/runtime/components/forms/Select.vue
@@ -319,3 +319,13 @@ export default defineComponent({
   }
 })
 </script>
+<style scoped>
+.form-select {
+  appearance: none; /* Remove default appearance */
+}
+
+.form-select::-ms-expand {
+  display: none; /* Internet Explorer 11 */
+}
+
+</style>

--- a/src/runtime/composables/usePopper.ts
+++ b/src/runtime/composables/usePopper.ts
@@ -1,7 +1,7 @@
 import { ref, onMounted, watchEffect } from 'vue'
 import type { Ref } from 'vue'
 import { popperGenerator, defaultModifiers } from '@popperjs/core/lib/popper-lite'
-import type { VirtualElement } from "@popperjs/core/lib/popper-lite"
+import type { VirtualElement } from '@popperjs/core/lib/popper-lite'
 import type { Instance } from '@popperjs/core'
 import { omitBy, isUndefined } from 'lodash-es'
 import flip from '@popperjs/core/lib/modifiers/flip'

--- a/src/runtime/composables/usePopper.ts
+++ b/src/runtime/composables/usePopper.ts
@@ -1,7 +1,7 @@
 import { ref, onMounted, watchEffect } from 'vue'
 import type { Ref } from 'vue'
-import { popperGenerator, defaultModifiers } from '@popperjs/core/lib/popper-lite';
-import type { VirtualElement } from "@popperjs/core/lib/popper-lite";
+import { popperGenerator, defaultModifiers } from '@popperjs/core/lib/popper-lite'
+import type { VirtualElement } from "@popperjs/core/lib/popper-lite"
 import type { Instance } from '@popperjs/core'
 import { omitBy, isUndefined } from 'lodash-es'
 import flip from '@popperjs/core/lib/modifiers/flip'
@@ -9,8 +9,8 @@ import offset from '@popperjs/core/lib/modifiers/offset'
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow'
 import computeStyles from '@popperjs/core/lib/modifiers/computeStyles'
 import eventListeners from '@popperjs/core/lib/modifiers/eventListeners'
-import { unrefElement } from '@vueuse/core';
-import type { MaybeElement } from "@vueuse/core";
+import { unrefElement } from '@vueuse/core'
+import type { MaybeElement } from '@vueuse/core'
 import type { PopperOptions } from '../types'
 
 export const createPopper = popperGenerator({

--- a/src/runtime/composables/usePopper.ts
+++ b/src/runtime/composables/usePopper.ts
@@ -1,6 +1,7 @@
 import { ref, onMounted, watchEffect } from 'vue'
 import type { Ref } from 'vue'
-import { popperGenerator, defaultModifiers, VirtualElement } from '@popperjs/core/lib/popper-lite'
+import { popperGenerator, defaultModifiers } from '@popperjs/core/lib/popper-lite';
+import type { VirtualElement } from "@popperjs/core/lib/popper-lite";
 import type { Instance } from '@popperjs/core'
 import { omitBy, isUndefined } from 'lodash-es'
 import flip from '@popperjs/core/lib/modifiers/flip'
@@ -8,7 +9,8 @@ import offset from '@popperjs/core/lib/modifiers/offset'
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow'
 import computeStyles from '@popperjs/core/lib/modifiers/computeStyles'
 import eventListeners from '@popperjs/core/lib/modifiers/eventListeners'
-import { MaybeElement, unrefElement } from '@vueuse/core'
+import { unrefElement } from '@vueuse/core';
+import type { MaybeElement } from "@vueuse/core";
 import type { PopperOptions } from '../types'
 
 export const createPopper = popperGenerator({


### PR DESCRIPTION
This pull request is meant to address two issues related to incorrect import statements and select tag style:

1. Corrected type import statements: Previously, in the `usePopper` composable, the code was importing the actual elements instead of their types. I have now fixed these import statements, ensuring the appropriate types are imported for better code clarity.

2. In addition to addressing import-related issues, I made enhancements to the `select` tag. By applying the `appearance-none` property to the `form-select` class, we can override the default styling of the select tag. This prevents the appearance of `duplicate dropdown arrows`.