### PR TITLE
feat(Skeleton): added `count` prop for multiple renders

### DIFF
--- a/docs/components/content/examples/SkeletonExampleCount.vue
+++ b/docs/components/content/examples/SkeletonExampleCount.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="flex flex-col items-center space-y-4 w-full">
+    <USkeleton class="h-12 w-full" :count="4" />
+  </div>
+</template>

--- a/docs/content/7.layout/3.skeleton.md
+++ b/docs/content/7.layout/3.skeleton.md
@@ -39,7 +39,7 @@ Use the `count` prop to specify the number of skeleton items to render.
 #code
 ```vue
 <template>
-  <div class="lex flex-col items-center space-y-4 w-full">
+  <div class="flex flex-col items-center space-y-4 w-full">
     <USkeleton class="h-12 w-full" :count="4" />
   </div>
 </template>

--- a/docs/content/7.layout/3.skeleton.md
+++ b/docs/content/7.layout/3.skeleton.md
@@ -28,6 +28,24 @@ Use to show a placeholder while content is loading.
 ```
 ::
 
+### Count
+
+Use the `count` prop to specify the number of skeleton items to render.
+
+::component-example
+#default
+:skeleton-example-count
+
+#code
+```vue
+<template>
+  <div class="lex flex-col items-center space-y-4 w-full">
+    <USkeleton class="h-12 w-full" :count="4" />
+  </div>
+</template>
+```
+::
+
 ## Props
 
 :component-props

--- a/src/runtime/components/layout/Skeleton.vue
+++ b/src/runtime/components/layout/Skeleton.vue
@@ -1,5 +1,9 @@
 <template>
-  <div :class="[ui.base, ui.background, ui.rounded]" />
+  <div
+    v-for="i in count"
+    :key="i"
+    :class="[ui.base, ui.background, ui.rounded, $attrs.class]"
+  />
 </template>
 
 <script lang="ts">
@@ -18,6 +22,10 @@ export default defineComponent({
     ui: {
       type: Object as PropType<Partial<typeof appConfig.ui.skeleton>>,
       default: () => appConfig.ui.skeleton
+    },
+    count: {
+      type: Number,
+      default: 1
     }
   },
   setup (props) {


### PR DESCRIPTION
Hi team 👋 

This PR will add a `count` prop to the Skeleton component. It aims to render multiple components using a prop, instead of bloating the `template` with the same component.

Thanks for the amazing work 🚀 