### PR TITLE
docs: dead links in `Form` and `FormGroup` pages

### DIFF
--- a/docs/content/3.forms/10.form.md
+++ b/docs/content/3.forms/10.form.md
@@ -3,7 +3,7 @@ description: Collect and validate form data.
 links:
   - label: GitHub
     icon: i-simple-icons-github
-    to: https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/forms/Form.ts
+    to: https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/forms/Form.vue
 ---
 
 ## Usage

--- a/docs/content/3.forms/9.form-group.md
+++ b/docs/content/3.forms/9.form-group.md
@@ -3,7 +3,7 @@ description: Display a label and additional informations around a form element.
 links:
   - label: GitHub
     icon: i-simple-icons-github
-    to: https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/forms/FormGroup.ts
+    to: https://github.com/nuxtlabs/ui/blob/dev/src/runtime/components/forms/FormGroup.vue
 ---
 
 


### PR DESCRIPTION
Pretty simple fix, I just noticed there was a typo in file extensions.